### PR TITLE
Fix: Pop-up confirmation not occurring when removing a question from questionnaire

### DIFF
--- a/app/views/questionnaires/_questionnaire.html.erb
+++ b/app/views/questionnaires/_questionnaire.html.erb
@@ -84,3 +84,9 @@
   <% end %>
 <% end %>
 <BR/>
+
+<script>
+$('a[data-method="delete"]').click(function(e) {
+    return window.confirm("It's the reviewing period now. All existing reviews for the questionnaire would be deleted. Are you sure you want to continue?");
+});
+</script>


### PR DESCRIPTION
Added short jQuery script which creates confirmation pop-up when removing a question.

This is a different pop-up and method than when you add a question as they are executed in different ways. As remove is more embedded in the html, this was I came up with and it applies to all question types without edits to their files